### PR TITLE
Scarb fmt the code and Fix the `scarb test` snforge installation

### DIFF
--- a/.github/workflows/scarb-ci.yml
+++ b/.github/workflows/scarb-ci.yml
@@ -9,20 +9,42 @@ on:
       - main
 
 jobs:
-  scarb-checks:
+  build:
+    name: Scarb Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set up Scarb
         uses: software-mansion/setup-scarb@v1
-
       - name: Build with Scarb
         run: scarb build
 
+  fmt:
+    name: Scarb Fmt Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Scarb
+        uses: software-mansion/setup-scarb@v1
       - name: Check formatting with Scarb
         run: scarb fmt --check
 
+  test:
+    name: Scarb Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Scarb
+        uses: software-mansion/setup-scarb@v1
+      - name: Install snforge
+        run: |
+          curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | bash
+          source $HOME/.bashrc
+          snfoundryup --version 0.44.0
       - name: Run tests with Scarb
-        run: scarb test
+        run: |
+          source $HOME/.bashrc
+          scarb test

--- a/.github/workflows/scarb-ci.yml
+++ b/.github/workflows/scarb-ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   scarb-checks:

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -130,15 +130,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.38.3"
+version = "0.44.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:0cd914b547acd96b4cad99a78e95c0eda001d0c280da4969b2161e286079cf46"
+checksum = "sha256:ec8c7637b33392a53153c1e5b87a4617ddcb1981951b233ea043cad5136697e2"
 
 [[package]]
 name = "snforge_std"
-version = "0.38.3"
+version = "0.44.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:d376526fbbe22535ad89ed630b11d6e209f22c50168de6c6430c0591c81c3174"
+checksum = "sha256:d4affedfb90715b1ac417b915c0a63377ae6dd69432040e5d933130d65114702"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,7 +10,7 @@ starknet = "2.11.1"
 openzeppelin = "1.0.0"
 
 [dev-dependencies]
-snforge_std = "0.38.3"
+snforge_std = "0.44.0"
 assert_macros = "2.11.1"
 
 [[target.starknet-contract]]
@@ -36,7 +36,7 @@ allow-prebuilt-plugins = ["snforge_std"]
 
 # [[tool.snforge.fork]]
 # name = "SOME_SECOND_NAME"
-# url = "http://your.second.rpc.url"                         
+# url = "http://your.second.rpc.url"
 # block_id.number = "123"                                    # Block to fork from (block number)
 
 # [[tool.snforge.fork]]

--- a/src/contracts/real_estate.cairo
+++ b/src/contracts/real_estate.cairo
@@ -3,17 +3,13 @@ mod RealEstateFractionalOwnership {
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
-    use rwax::events::{
-        property::{PropertyAdded, PropertyListed, PropertySold},
-        proporsal::{ProposalCreated, ProposalExecuted},
-        rental::{RentalIncomeClaimed, RentalIncomeDistributed},
-        vote::VoteCast,
-    };
+    use rwax::events::property::{PropertyAdded, PropertyListed, PropertySold};
+    use rwax::events::proporsal::{ProposalCreated, ProposalExecuted};
+    use rwax::events::rental::{RentalIncomeClaimed, RentalIncomeDistributed};
+    use rwax::events::vote::VoteCast;
     use rwax::interfaces::ireal_estate::IRealEstateFractionalOwnership;
-    use rwax::structs::{
-        property::PropertyDetails,
-        proporsal::Proposal,
-    };
+    use rwax::structs::property::PropertyDetails;
+    use rwax::structs::proporsal::Proposal;
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,


### PR DESCRIPTION
`scarb test` github actions was failing due to `snforge` installation which is required for running `scarb test`. This PR fixes this issue and also applies the `scarb fmt` to format the existing code properly in order for the `scarb fmt` test too to pass.