### PR TITLE
Remove unnecessary code from lib.cairo file

### DIFF
--- a/src/interfaces/irwa_factory.cairo
+++ b/src/interfaces/irwa_factory.cairo
@@ -1,5 +1,5 @@
 use starknet::ContractAddress;
-use rwax::structs::asset::AssetData;
+// use rwax::structs::asset::AssetData;
 
 #[starknet::interface]
 pub trait IRWAFactory<TContractState> {
@@ -8,16 +8,12 @@ pub trait IRWAFactory<TContractState> {
     /// Creates a new RWA token (ERC721 NFT) representing a real-world asset
     /// Only callable by addresses with TOKENIZER_ROLE
     fn tokenize_asset(
-        ref self: TContractState,
-        owner: ContractAddress,
-        asset_data: AssetData
+        ref self: TContractState, owner: ContractAddress, asset_data: felt252 // AssetData
     ) -> u256;
 
     /// Updates metadata for an existing asset (only by owner or authorized operator)
     fn update_asset_metadata(
-        ref self: TContractState,
-        token_id: u256,
-        new_data: AssetData
+        ref self: TContractState, token_id: u256, new_data: felt252 // AssetData
     );
 
     // ===== ACCESS CONTROL =====
@@ -31,7 +27,7 @@ pub trait IRWAFactory<TContractState> {
     // ===== VIEW FUNCTIONS =====
 
     /// Returns asset metadata for a given token ID
-    fn get_asset_data(self: @TContractState, token_id: u256) -> AssetData;
+    fn get_asset_data(self: @TContractState, token_id: u256) -> felt252; //AssetData;
 
     /// Checks if an address has TOKENIZER_ROLE
     fn has_tokenizer_role(self: @TContractState, account: ContractAddress) -> bool;

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,34 +1,3 @@
 pub mod interfaces {
-    pub mod iprecious_metal;
-    pub mod ireal_estate;
-}
-
-pub mod contracts {
-    pub mod real_estate;
-    pub mod precious_metal;
-}
-
-pub mod events {
-    // real estate events
-    pub mod property;
-    pub mod proporsal;
-    pub mod rental;
-    pub mod vote;
-
-    // metal events
-    pub mod metal_property;
-    pub mod metal_proposal;
-    pub mod metal_vote;
-    pub mod metal_finance;
-    pub mod metal_bulk_sales;
-}
-
-pub mod structs {
-    // real estate structs
-    pub mod property;
-    pub mod proporsal;
-
-    // metal structs
-    pub mod metal_property;
-    pub mod metal_proposal;
+    pub mod irwa_factory;
 }


### PR DESCRIPTION
remove unnecessary code from `lib.cairo`.

Closes #60 