### PR TITLE
fix: expose AssetData and update asset struct derive to resolve facto…

### DIFF
--- a/src/interfaces/irwa_factory.cairo
+++ b/src/interfaces/irwa_factory.cairo
@@ -1,5 +1,5 @@
+use rwax::structs::asset::AssetData;
 use starknet::ContractAddress;
-// use rwax::structs::asset::AssetData;
 
 #[starknet::interface]
 pub trait IRWAFactory<TContractState> {
@@ -8,13 +8,11 @@ pub trait IRWAFactory<TContractState> {
     /// Creates a new RWA token (ERC721 NFT) representing a real-world asset
     /// Only callable by addresses with TOKENIZER_ROLE
     fn tokenize_asset(
-        ref self: TContractState, owner: ContractAddress, asset_data: felt252 // AssetData
+        ref self: TContractState, owner: ContractAddress, asset_data: AssetData,
     ) -> u256;
 
     /// Updates metadata for an existing asset (only by owner or authorized operator)
-    fn update_asset_metadata(
-        ref self: TContractState, token_id: u256, new_data: felt252 // AssetData
-    );
+    fn update_asset_metadata(ref self: TContractState, token_id: u256, new_data: AssetData);
 
     // ===== ACCESS CONTROL =====
 
@@ -27,7 +25,7 @@ pub trait IRWAFactory<TContractState> {
     // ===== VIEW FUNCTIONS =====
 
     /// Returns asset metadata for a given token ID
-    fn get_asset_data(self: @TContractState, token_id: u256) -> felt252; //AssetData;
+    fn get_asset_data(self: @TContractState, token_id: u256) -> AssetData;
 
     /// Checks if an address has TOKENIZER_ROLE
     fn has_tokenizer_role(self: @TContractState, account: ContractAddress) -> bool;

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,6 +3,11 @@ pub mod interfaces {
 }
 
 pub mod events {
-    // pub mod factory;
+    pub mod factory;
     pub mod fractionalization;
 }
+
+pub mod structs {
+    pub mod asset;
+}
+

--- a/src/structs/asset.cairo
+++ b/src/structs/asset.cairo
@@ -1,4 +1,4 @@
-#[derive(Copy, Drop, Serde, starknet::Store)]
+#[derive(Drop, Serde, starknet::Store)]
 pub struct AssetData {
     pub asset_type: felt252, // "REAL_ESTATE", "PRECIOUS_METAL", "ART", etc.
     pub name: ByteArray,


### PR DESCRIPTION
### Summary
This PR fixes the compilation error (#86) caused by the factory event referencing `AssetData`, which was not exposed in `lib.cairo`.  

### Changes Made
- Uncommented `pub mod factory;` in `src/lib.cairo`.
- Added `pub mod asset;` under `pub mod structs` in `src/lib.cairo`.
- Imported `AssetData` from `structs::asset`.
- Updated `src/structs/asset.cairo` by removing `Copy` from `#[derive(...)]` (now `#[derive(Drop, Serde, starknet::Store)]`).

### Testing
- No compilation errors remain for the factory event.

### Related Issue
Closes #86.
